### PR TITLE
addMult forms a monoid, but with neutral element (1,0) rather than (0,0)

### DIFF
--- a/HSoM/Examples/SelfSimilar.lhs
+++ b/HSoM/Examples/SelfSimilar.lhs
@@ -7,7 +7,7 @@
 > type SNote    = (Dur,AbsPitch)
 
 > selfSim      :: [SNote] -> Cluster
-> selfSim pat  = Cluster (0,0) (map mkCluster pat)
+> selfSim pat  = Cluster (1,0) (map mkCluster pat)
 >     where mkCluster note =
 >             Cluster note (map (mkCluster . addMult note) pat)
 


### PR DESCRIPTION
Hi, Donya. I think the morally right seed value for growing a self-similar tree of notes is (1,0) rather than (0,0), because this is the neutral value of the (associative!) operator addMult. 